### PR TITLE
Add app_name to urls.py

### DIFF
--- a/djpaddle/urls.py
+++ b/djpaddle/urls.py
@@ -2,6 +2,8 @@ from django.urls import path
 
 from . import views
 
+app_name = 'djpaddle'
+
 urlpatterns = [
     path("webhook/", views.paddle_webhook_view, name="webhook"),
 ]


### PR DESCRIPTION
This fixes a deprecation error in Django 2.0.

https://stackoverflow.com/questions/48608894/impropyconfigurederror-about-app-name-when-using-namespace-in-include